### PR TITLE
remove Supressor.jl dep, generalize IO handling, print more info to repl

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ By default, you need to specify ~julia-vterm~ as the language name for source bl
 - A src code block with ~julia-vterm~ (or ~julia~ if you define the above alias) specified as language will be executed in a julia-vterm REPL.
 - You can specify ~value~ (functional mode, default) or ~output~ (scripting mode) for ~:results~.
 - Session-based evaluation is supported.
-  - Without ~:session~, the code block is executed in its own session.
+  - Without ~:session~, the code block is executed inside a `let` block.
   - With ~:session~, the code block is executed in ~main~ session.
   - With ~:session <name>~, the code block is executed in the named session.
   - Unlike most other ob-* packages, the buffer name for the Julia session will be automatically formatted as ~*julia:<name>*~. So, you can just specify the pure name, such as ~main~ or ~ses1~, for the session name.

--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@ Ob-julia-vterm provides Org-babel support for Julia code blocks using julia-vter
 
 ** Installation
 
-You need to have [[https://github.com/shg/julia-vterm.el][julia-vterm]] installed in Emacs. Also, to use ~:results output~, [[https://github.com/JuliaIO/Suppressor.jl][Suppressor.jl]] needs to be installed in Julia environment.
+You need to have [[https://github.com/shg/julia-vterm.el][julia-vterm]] installed in Emacs.
 
 You can install ob-julia-vterm from MELPA. If you want to install it manually, download ob-julia-vterm.el into somewhere in your local directory and install it with the following.
 

--- a/ob-julia-vterm.el
+++ b/ob-julia-vterm.el
@@ -50,20 +50,26 @@
 (defun org-babel-julia-vterm--wrap-body (result-type verbose session out-file body)
   "Return Julia code that execute-s BODY and save-s the results in OUT-FILE according to RESULT-TYPE, VERBOSE, and SESSION."
   (format (concat
-	   (if verbose "using Logging: Logging;" "")
+	   (if verbose
+	       "using Logging: Logging;" "")
 	   "_julia_vterm_outfile = open(\"%s\", \"w\");"
 	   (if (eq result-type 'output)
-	       "_julia_vterm_stdout = stdout; redirect_stdout(_julia_vterm_outfile);" "")
+	       "_julia_vterm_stdout = stdout;redirect_stdout(_julia_vterm_outfile);" "")
+	   (if (and (eq result-type 'output) verbose)
+	       "_julia_vterm_stderr = stderr;redirect_stderr(_julia_vterm_outfile);" "")
 	   (if verbose
-	       "_julia_vterm_stderr = stderr; redirect_stderr(_julia_vterm_outfile); _julia_vterm_logger = Logging.global_logger(); Logging.global_logger(Logging.ConsoleLogger(_julia_vterm_outfile, Logging.Debug));" "")
+	       "_julia_vterm_logger = Logging.global_logger();Logging.global_logger(Logging.ConsoleLogger(_julia_vterm_outfile, Logging.Debug));" "")
 	   "_julia_vterm_value = " (if session "begin" "let") "
 %s
 end;"
 	   (if verbose
-	       "Logging.global_logger(_julia_vterm_logger); redirect_stderr(_julia_vterm_stderr)
-" "")
-	   (if (eq result-type 'value) "print(_julia_vterm_outfile, _julia_vterm_value);" "")
-	   (if (eq result-type 'output) "redirect_stdout(_julia_vterm_stdout);" "")
+	       "Logging.global_logger(_julia_vterm_logger);" "")
+	   (if (eq result-type 'value)
+	       "print(_julia_vterm_outfile, _julia_vterm_value);" "")
+	   (if (eq result-type 'output)
+	       "redirect_stdout(_julia_vterm_stdout);" "")
+	   (if (and (eq result-type 'output) verbose)
+	       "redirect_stderr(_julia_vterm_stderr);" "")
 	   "close(_julia_vterm_outfile)")
 	  out-file body))
 

--- a/ob-julia-vterm.el
+++ b/ob-julia-vterm.el
@@ -7,7 +7,7 @@
 ;; Created: October 31, 2020
 ;; URL: https://github.com/shg/ob-julia-vterm.el
 ;; Package-Requires: ((emacs "26.1") (julia-vterm "0.10"))
-;; Version: 0.3
+;; Version: 0.2
 ;; Keywords: julia, org, outlines, literate programming, reproducible research
 
 ;; This file is not part of GNU Emacs.
@@ -33,9 +33,12 @@
 
 ;;; Requirements:
 
-;; This package uses julia-vterm to run Julia code.
+;; This package uses julia-vterm to run Julia code.  You also need to
+;; have Suppressor.jl package installed in your Julia environment to
+;; use :results output.
 ;;
 ;; - https://github.com/shg/julia-vterm.el
+;; - https://github.com/JuliaIO/Suppressor.jl
 ;;
 ;; See https://github.com/shg/ob-julia-vterm.el for installation
 ;; instructions.
@@ -46,36 +49,37 @@
 (require 'julia-vterm)
 
 (defvar org-babel-julia-vterm-debug nil)
+(defun org-babel-julia-vterm--wrap-body (result-type session body)
+  "Make Julia code that execute-s BODY and obtains the results, depending on RESULT-TYPE and SESSION."
+  (concat
+   (if session "" "let\n")
+   body
+   (if session "" "end\n")))
 
-(defun org-babel-julia-vterm--wrap-body (result-type verbose session out-file body)
-  "Return Julia code that execute-s BODY and save-s the results in OUT-FILE according to RESULT-TYPE, VERBOSE, and SESSION."
-  (format (concat
-	   (if verbose
-	       "using Logging: Logging;" "")
-	   "_julia_vterm_outfile = open(\"%s\", \"w\");"
-	   (if (eq result-type 'output)
-	       "_julia_vterm_stdout = stdout;redirect_stdout(_julia_vterm_outfile);" "")
-	   (if (and (eq result-type 'output) verbose)
-	       "_julia_vterm_stderr = stderr;redirect_stderr(_julia_vterm_outfile);" "")
-	   (if verbose
-	       "_julia_vterm_logger = Logging.global_logger();Logging.global_logger(Logging.ConsoleLogger(_julia_vterm_outfile, Logging.Debug));" "")
-	   "_julia_vterm_value = " (if session "begin" "let") "
-%s
-end;"
-	   (if verbose
-	       "Logging.global_logger(_julia_vterm_logger);" "")
-	   (if (eq result-type 'value)
-	       "print(_julia_vterm_outfile, _julia_vterm_value);" "")
-	   (if (eq result-type 'output)
-	       "redirect_stdout(_julia_vterm_stdout);" "")
-	   (if (and (eq result-type 'output) verbose)
-	       "redirect_stderr(_julia_vterm_stderr);" "")
-	   "close(_julia_vterm_outfile)")
-	  out-file body))
-
-(defun org-babel-julia-vterm--make-str-to-run (src-file)
-  "Return Julia code that load-s SRC-FILE."
-  (format "include(\"%s\")\n" src-file))
+(defun org-babel-julia-vterm--make-str-to-run (result-type src-file out-file)
+  "Make Julia code that load-s SRC-FILE and save-s the result to OUT-FILE, depending on RESULT-TYPE."
+  (format
+   (cond ((eq result-type 'output) "\
+using Logging: Logging; let
+    out_file = \"%s\"
+    result = open(out_file, \"w\") do io
+        logger = Base.SimpleLogger(io)
+        redirect_stdout(io) do
+            Logging.with_logger(logger) do
+                include(\"%s\") 
+            end
+        end
+    end
+    open(io -> println(read(io, String)), out_file)
+    result
+end\n")
+	 ((eq result-type 'value) "\
+open(\"%s\", \"w\") do io
+    result = include(\"%s\")
+    print(io, result)
+    result
+end\n"))
+   out-file src-file))
 
 (defun org-babel-execute:julia-vterm (body params)
   "Execute a block of Julia code with Babel.
@@ -96,17 +100,16 @@ BODY is the contents and PARAMS are header arguments of the code block."
 
 (defun org-babel-julia-vterm-evaluate (session body result-type params)
   "Evaluate BODY as Julia code in a julia-vterm buffer specified with SESSION."
-  (let* ((src-file (org-babel-temp-file "julia-vterm-src-"))
-	 (out-file (org-babel-temp-file "julia-vterm-out-"))
-	 (verbose (member "verbose" (cdr (assq :result-params params))))
-	 (src (org-babel-julia-vterm--wrap-body result-type verbose session out-file body)))
+  (let ((src-file (org-babel-temp-file "julia-vterm-src-"))
+	(out-file (org-babel-temp-file "julia-vterm-out-"))
+	(src (org-babel-julia-vterm--wrap-body result-type session body)))
     (with-temp-file src-file (insert src))
     (when org-babel-julia-vterm-debug
       (julia-vterm-paste-string
        (format "#= params ======\n%s\n== src =========\n%s===============#\n" params src)
        session))
     (julia-vterm-paste-string
-     (org-babel-julia-vterm--make-str-to-run src-file)
+     (org-babel-julia-vterm--make-str-to-run result-type src-file out-file)
      session)
     (let ((c 0))
       (while (and (< c 100) (= 0 (file-attribute-size (file-attributes out-file))))


### PR DESCRIPTION
Okay, so this is a less ambitious change than #5 but if it is inconvenient for you don't feel pressured to use it. This should be functionally the same as before, but no longer relies on Supressor.jl and will print more useful info in the repl. 

For instance if I do
![image](https://user-images.githubusercontent.com/29157027/116176823-06a7ca00-a6d0-11eb-9551-f91a2b91b060.png)
it behaves the same in-buffer but at the `REPL` we get all the relevant info as well as the returned value:
![image](https://user-images.githubusercontent.com/29157027/116176925-2d660080-a6d0-11eb-91df-02016a533a94.png)

_________

and with `value` instead of `output` we get
![image](https://user-images.githubusercontent.com/29157027/116176503-79fd0c00-a6cf-11eb-8d0d-4cfa51bc9456.png)
and
![image](https://user-images.githubusercontent.com/29157027/116176979-466eb180-a6d0-11eb-91a3-e74cc689b3b2.png)
