### PR TITLE
Load `org-id`

### DIFF
--- a/ob-julia-vterm.el
+++ b/ob-julia-vterm.el
@@ -43,6 +43,7 @@
 ;;; Code:
 
 (require 'ob)
+(require 'org-id)
 (require 'queue)
 (require 'filenotify)
 (require 'julia-vterm)


### PR DESCRIPTION
Honestly, I don't know anything about developing Emacs packages. I was playing around with your package since I was looking for an alternative to emacs-jupyter (which annoyingly needs Jupyter...), and noticed that in my slimmed down Emacs without default config I ran into `symbol's definition is void: org-id-uuid` errors. It seems manually loading `(require 'org-id)` resolves the issue, so I assumed that maybe that should be added to the package. Apart from that your package seems to work well, thanks a lot!