### PR TITLE
Change errors to showerror

### DIFF
--- a/ob-julia-vterm.el
+++ b/ob-julia-vterm.el
@@ -71,9 +71,7 @@ using Logging: Logging; let
             try
                 include(\"%s\")
             catch e
-                Logging.with_logger(logger) do
-                    @error e
-                end
+                showerror(logger.stream, e)
             end
         end
     end
@@ -98,10 +96,7 @@ using Logging: Logging; open(\"%s\", \"w\") do io
         Base.invokelatest(print, io, result)
         result
     catch e
-        Logging.with_logger(logger) do
-            @error e
-        end
-        e
+        showerror(logger.stream, e)
     end
 end #OB-JULIA-VTERM_END\n"))
    (substring uuid 0 8) out-file src-file))

--- a/ob-julia-vterm.el
+++ b/ob-julia-vterm.el
@@ -96,7 +96,9 @@ using Logging: Logging; open(\"%s\", \"w\") do io
         Base.invokelatest(print, io, result)
         result
     catch e
-        showerror(logger.stream, e)
+        msg = sprint(showerror, e)
+        println(logger.stream, msg)
+        println(msg)
     end
 end #OB-JULIA-VTERM_END\n"))
    (substring uuid 0 8) out-file src-file))


### PR DESCRIPTION
Currently, ob-julia-vterm logs the error object without showing the corresponding error. Using the showerror method instead of @error should provide more info about the error.