### PR TITLE
remove synchronous hold in callback

### DIFF
--- a/ob-julia-vterm.el
+++ b/ob-julia-vterm.el
@@ -185,7 +185,6 @@ BODY is the contents and PARAMS are header arguments of the code block."
 		    (when (and (not (equal .src-block-begin .src-block-end))
 			       (or (eq (org-element-type (org-element-context)) 'src-block)
 				   (eq (org-element-type (org-element-context)) 'inline-src-block)))
-		      (ob-julia-vterm-wait-for-file-change .out-file 10 0.1)
 		      (let ((result (with-temp-buffer
 				      (insert-file-contents .out-file)
 				      (buffer-string)))


### PR DESCRIPTION
Remove the call of  `ob-julia-vterm-wait-for-file-change` in `ob-julia-vterm-evaluation-completed-callback-func`.

Closes #26.